### PR TITLE
Added `filtfilt` convenience function to iir and fir.

### DIFF
--- a/src/firFilter.js
+++ b/src/firFilter.js
@@ -2,6 +2,7 @@
 
 var {
   runMultiFilter,
+  runMultiFilterReverse,
   complex,
   evaluatePhase
 } = require('./utils')
@@ -102,6 +103,10 @@ var FirFilter = function (filter) {
     },
     multiStep: function (input, overwrite) {
       return runMultiFilter(input, z, doStep, overwrite)
+    },
+    filtfilt: function (input, overwrite) {
+      return runMultiFilterReverse(runMultiFilter(
+        input, z, doStep, overwrite), z, doStep, true)
     },
     reinit: function () {
       z = initZero(f.length - 1)

--- a/src/iirFilter.js
+++ b/src/iirFilter.js
@@ -3,6 +3,7 @@
 var {
   complex,
   runMultiFilter,
+  runMultiFilterReverse,
   evaluatePhase
 } = require('./utils')
 
@@ -214,6 +215,10 @@ var IirFilter = function (filter) {
     },
     multiStep: function (input, overwrite) {
       return runMultiFilter(input, cf, doStep, overwrite)
+    },
+    filtfilt: function (input, overwrite) {
+      return runMultiFilterReverse(runMultiFilter(
+          input, cf, doStep, overwrite), cf, doStep, true)
     },
     simulate: function (input) {
       return calcInputResponse(input)

--- a/src/utils.js
+++ b/src/utils.js
@@ -64,6 +64,18 @@ exports.runMultiFilter = function (input, d, doStep, overwrite) {
   return out
 }
 
+exports.runMultiFilterReverse = function (input, d, doStep, overwrite) {
+  var out = []
+  if (overwrite) {
+    out = input
+  }
+  var i
+  for (i = input.length - 1; i >= 0; i--) {
+    out[i] = doStep(input[i], d)
+  }
+  return out
+}
+
 var factorial = function (n, a) {
   if (!a) {
     a = 1


### PR DESCRIPTION
Added function `filtfilt` that performs phase neutral filtering
by first applying an `iirFliter` or `firFilter` in forward and
then in backward direction.

The name `filtfilt` is customary in other signal processing libraries, `scipy.signal`, `matlab`.